### PR TITLE
fix: success response handling + headers error + dynamic article loading

### DIFF
--- a/Controllers/wallabagButtonController.php
+++ b/Controllers/wallabagButtonController.php
@@ -96,10 +96,13 @@ class FreshExtension_wallabagButton_Controller extends Minz_ActionController
     Minz_Request::good(_t('ext.wallabagButton.notifications.authorization_revoked'), $url_redirect);
   }
 
+  /**
+   * @param array<string,mixed> $data Data to be JSON-encoded and sent as response
+   */
   private function sendJsonResponse(array $data): void
   {
     $this->view->_layout(null);
-    $this->view->result_json = json_encode($data);
+    $this->view->result_json = json_encode($data, JSON_UNESCAPED_UNICODE) ?: '{}';
     $this->view->_path('wallabagButton/result.json');
     header('Content-Type: application/json; charset=utf-8');
   }

--- a/Controllers/wallabagButtonController.php
+++ b/Controllers/wallabagButtonController.php
@@ -96,16 +96,22 @@ class FreshExtension_wallabagButton_Controller extends Minz_ActionController
     Minz_Request::good(_t('ext.wallabagButton.notifications.authorization_revoked'), $url_redirect);
   }
 
-  public function addAction(): void
+  private function sendJsonResponse(array $data): void
   {
     $this->view->_layout(null);
+    $this->view->result_json = json_encode($data);
+    $this->view->_path('wallabagButton/result.json');
+    header('Content-Type: application/json; charset=utf-8');
+  }
 
+  public function addAction(): void
+  {
     $entry_id = Minz_Request::paramString('id');
     $entry_dao = FreshRSS_Factory::createEntryDao();
     $entry = $entry_dao->searchById($entry_id);
 
     if ($entry === null) {
-      echo json_encode(array('status' => 404));
+      $this->sendJsonResponse(array('status' => 404));
       return;
     }
 
@@ -114,7 +120,7 @@ class FreshExtension_wallabagButton_Controller extends Minz_ActionController
     );
 
     $result = $this->curlPostRequest("/api/entries", $post_data, true);
-    echo json_encode($result);
+    $this->sendJsonResponse($result);
   }
 
   private function isAccessTokenValid(): bool

--- a/Models/View.php
+++ b/Models/View.php
@@ -7,5 +7,6 @@ namespace WallabagButton;
 final class View extends \Minz_View {
 
   public string $wallabag_button_vars = '';
+  public string $result_json = '';
 
 }

--- a/static/script.js
+++ b/static/script.js
@@ -122,10 +122,11 @@ async function add_to_wallabag(wallabagButton, active)
       }
 
       let json = await response.json();
-      if (!json)
+      if (!json || json.status >= 400 || !json.response || !json.response.title)
       {
+        const errorCode = (json && (json.errorCode || json.status)) || 'unknown';
+        openNotification(wallabag_button_vars.i18n.failed_to_add_article_to_wallabag.replace('%s', errorCode), 'wallabag_button_bad');
         requestFailed(activeId, wallabagButtonImg, loadingAnimation);
-        openNotification(wallabag_button_vars.i18n.failed_to_add_article_to_wallabag.replace('%s', json.errorCode), 'wallabag_button_bad');
         return;
       }
 

--- a/static/script.js
+++ b/static/script.js
@@ -111,7 +111,7 @@ async function add_to_wallabag(wallabagButton, active)
       wallabagButtonImg.classList.remove("wb_disabled");
       loadingAnimation.classList.add("wb_disabled");
 
-      if (!response.ok || response != 301)
+      if (!response.ok)
       {
         if (response.status === 404)
         {

--- a/static/script.js
+++ b/static/script.js
@@ -8,29 +8,26 @@ if (document.readyState && document.readyState !== 'loading')
 
 async function documentReady()
 {
-  var wallabagButtons = document.querySelectorAll('#stream .flux a.wallabagButton');
-  for (var i = 0; i < wallabagButtons.length; i++)
+  // Use capture-phase event delegation so dynamically added buttons work
+  document.addEventListener('click', function (e)
   {
-    let wallabagButton = wallabagButtons[i];
-    wallabagButton.addEventListener('click', async function (e)
+    const wallabagButton = e.target.closest('#stream .flux a.wallabagButton');
+    if (!wallabagButton)
     {
-      if (!wallabagButton)
-      {
-        return;
-      }
+      return;
+    }
 
-      var active = wallabagButton.closest(".flux");
-      if (!active)
-      {
-        return;
-      }
+    e.preventDefault();
+    e.stopPropagation();
 
-      e.preventDefault();
-      e.stopPropagation();
+    const active = wallabagButton.closest(".flux");
+    if (!active)
+    {
+      return;
+    }
 
-      await add_to_wallabag(wallabagButton, active);
-    }, false);
-  }
+    add_to_wallabag(wallabagButton, active);
+  }, true);
 
   if (wallabag_button_vars.keyboard_shortcut)
   {

--- a/views/wallabagButton/result.json
+++ b/views/wallabagButton/result.json
@@ -1,0 +1,1 @@
+<?= $this->result_json ?>

--- a/views/wallabagButton/result.json
+++ b/views/wallabagButton/result.json
@@ -1,1 +1,2 @@
 <?= $this->result_json ?>
+


### PR DESCRIPTION
## Summary

This PR fixes three critical bugs that were causing the Wallabag button to fail silently, show raw JSON in the browser, and produce PHP warnings.

---

### Bug 1: JavaScript always treated API responses as failures

**File:** `static/script.js`  
**Root cause:** The condition `if (!response.ok || response != 301)` compared a `Response` object to the number `301`. In JavaScript, object-to-primitive comparison with `!=` is always `true`, so every API response — even HTTP 200 — took the error path and showed the "internet connection problems" notification.

**Fix:** Removed the broken `response != 301` check, leaving only `if (!response.ok)`.

---

### Bug 2: False "Added undefined to Wallabag" success on auth failures

**File:** `static/script.js`  
**Root cause:** The PHP backend wraps the Wallabag API response in its own JSON. On auth failure, the HTTP status is still `200`, but the JSON body contains `status: 401` and no `response.title`. The JS only checked `if (!json)`, so it treated the error payload as a success and rendered `"Added undefined to Wallabag"`.

**Fix:** Added JSON-body validation after `response.ok`: checks for `status >= 400`, missing `response` object, and missing `title` before entering the success path.

---

### Bug 3: Raw JSON shown for dynamically loaded articles

**File:** `static/script.js`  
**Root cause:** Click listeners were only attached to buttons present at page load. FreshRSS loads new articles dynamically as you scroll. Those new buttons had no listeners, so clicks either fell through to the `<a href>` navigation (showing raw API JSON) or bubbled up to FreshRSS's article expand/collapse handler.

**Fix:** Replaced per-element `addEventListener` with capture-phase event delegation on `document`, using `e.target.closest()` to intercept clicks on dynamically added `.wallabagButton` elements.

---

### Bug 4: PHP "headers already sent" warning

**File:** `Controllers/wallabagButtonController.php`  
**Root cause:** `addAction()` called `echo json_encode(...)` directly, sending output before FreshRSS could set HTTP headers.

**Fix:** Refactored to use a view-based approach:
- Created `views/wallabagButton/result.json` template
- Added `sendJsonResponse()` helper that assigns JSON to the view
- Added `json_encode()` fallback (`?: '{}'`) to handle encoding failures gracefully
- Added PHPDoc for type documentation

**Also fixed:**
- **File:** `Models/View.php` — Added missing `$result_json` property that `sendJsonResponse()` assigns to.

---

### Result
- ✅ The "A request has failed" browser notification is gone
- ✅ The "Added undefined" false success notification is gone — auth failures now correctly show "Failed to add article: 401"
- ✅ Raw JSON no longer appears when clicking dynamically loaded articles
- ✅ The "headers already sent" PHP warning is eliminated
- ✅ Code passes `php -l` syntax linting