### PR TITLE
fix(controller): actually load and wire up the WallabagButton\View class

### DIFF
--- a/Controllers/wallabagButtonController.php
+++ b/Controllers/wallabagButtonController.php
@@ -1,9 +1,16 @@
 <?php
 
+require_once __DIR__ . '/../Models/View.php';
+
 class FreshExtension_wallabagButton_Controller extends Minz_ActionController
 {
   /** @var WallabagButton\View */
   protected $view;
+
+  public function __construct()
+  {
+    parent::__construct(\WallabagButton\View::class);
+  }
 
   public function jsVarsAction(): void
   {


### PR DESCRIPTION
## Summary

`sendJsonResponse()` and `jsVarsAction()` assign to `$this->view->result_json` and `$this->view->wallabag_button_vars`, both declared on the `WallabagButton\View` subclass (`Models/View.php`, added in #23). But the controller never actually uses that subclass:

- `Minz_ActionController::__construct(string $viewType = '')` only uses a custom view class if you pass its name explicitly — `FreshExtension_wallabagButton_Controller` never overrides the constructor, so it always falls back to the base `Minz_View`, which doesn't declare `result_json`/`wallabag_button_vars`.
- Even if it did pass the class name, nothing loads `Models/View.php` in the first place — the extension class doesn't implement `autoload()` (the only mechanism `Minz_ExtensionManager` uses to register a per-extension autoloader), so `class_exists('WallabagButton\View')` returns `false`.

On PHP 8.4, assigning to an undeclared property on `Minz_View` triggers a "Creation of dynamic property" **deprecation notice**. With `display_errors` on, PHP prints that notice directly into the HTTP response body *before* the JSON payload from `sendJsonResponse()` — corrupting it. The browser's `fetch().then(r => r.json())` then throws a `SyntaxError` on the malformed body, which hits the `.catch()` handler and shows the generic "A request has failed, it may have been caused by internet connection problems" notification — **even when the underlying Wallabag API call succeeded** (the article gets saved, but the UI reports failure every time).

## Fix

- Add a constructor that passes `\WallabagButton\View::class` to `parent::__construct()`.
- Add the missing `require_once __DIR__ . '/../Models/View.php';` so the class actually exists to be referenced.

## How I found this

Diagnosing this required working through several layers (an unrelated but real CAINFO null-check bug already fixed in #22/0.8, some Tailscale/NAT networking dead ends on my own setup, and confirming the extension image needed a rebuild since `extensions/` is baked in at Docker build time rather than bind-mounted). Once I added temporary `error_log()` calls around the `curl_exec()` call and the JSON response body, the deprecation notice leaking into the response was directly visible in the browser's dev tools network tab. I'm disclosing that this fix was found and written with AI assistance (Claude Code), verified against a live reproduction on my own FreshRSS + Wallabag deployment (confirmed broken on stock 0.8, confirmed fixed with this patch).

## Testing
- Reproduced on a live FreshRSS 1.29.1 + Wallabag 2.6.13 deployment running this extension at `0.8` (unmodified): every "add to Wallabag" click showed the failure notification despite the article being saved correctly in Wallabag.
- Applied this patch on top of `0.8`: notification now correctly shows success, with no functional change to any other behavior.